### PR TITLE
Improve `fs__chmod()` and `fs__access()` to honor win32 ACLs

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -36,6 +36,8 @@
 #include "handle-inl.h"
 
 #include <wincrypt.h>
+#include <accctrl.h> /* for SE_FILE_OBJECT constant */
+#include <aclapi.h>  /* for SetEntriesInAcl() */
 
 
 #define UV_FS_FREE_PATHS         0x0002
@@ -1738,10 +1740,236 @@ accesscheck_cleanup:
   SET_REQ_SUCCESS(req);
 }
 
+static void build_access_struct(EXPLICIT_ACCESS_W* ea, PSID owner,
+                                TRUSTEE_TYPE user_type, mode_t mode_triplet,
+                                ACCESS_MODE allow_deny) {
+  /*
+   * We map the typical POSIX mode bits r/w/x as the Windows
+   * FILE_GENERIC_{READ,WRITE,EXECUTE} permissions.
+   */
+  ZeroMemory(ea, sizeof(EXPLICIT_ACCESS_W));
+
+  /*
+   * Initialize two EXLPICIT_ACCESS structures; one to explicitly allow things, the
+   * other to explicitly deny them.  We leave no middle ground for inheritance to mess
+   * things up.
+   */
+  ea->grfAccessPermissions = 0;
+  ea->grfInheritance = NO_INHERITANCE;
+  ea->Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
+  ea->Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  ea->Trustee.TrusteeType = user_type;
+  ea->Trustee.ptstrName = owner;
+
+  ea->grfAccessMode = allow_deny;
+
+  if (mode_triplet & 0x1)
+    ea->grfAccessPermissions |= FILE_GENERIC_EXECUTE;
+
+  if (mode_triplet & 0x2)
+    ea->grfAccessPermissions |= FILE_GENERIC_WRITE;
+
+  if (mode_triplet & 0x4)
+    ea->grfAccessPermissions |= FILE_GENERIC_READ;
+}
 
 static void fs__chmod(uv_fs_t* req) {
-  int result = _wchmod(req->file.pathw, req->fs.info.mode);
-  SET_REQ_RESULT(req, result);
+  PACL pOldDACL = NULL, pNewDACL = NULL;
+  PSID psidOwner = NULL, psidGroup = NULL, psidEveryone = NULL,
+       psidNull = NULL, psidCreatorGroup = NULL;
+  PSECURITY_DESCRIPTOR pSD = NULL;
+  PEXPLICIT_ACCESS_W ea = NULL, poldEAs = NULL;
+
+  /* Create well-known SIDs for various global groups */
+  SID_IDENTIFIER_AUTHORITY SIDAuthWorld = SECURITY_WORLD_SID_AUTHORITY;
+  SID_IDENTIFIER_AUTHORITY SIDAuthNull = SECURITY_NULL_SID_AUTHORITY;
+  SID_IDENTIFIER_AUTHORITY SIDAuthCreator = SECURITY_CREATOR_SID_AUTHORITY;
+
+  if (!AllocateAndInitializeSid(&SIDAuthWorld, 1, SECURITY_WORLD_RID,
+                                0, 0, 0, 0, 0, 0, 0, &psidEveryone) ||
+      !AllocateAndInitializeSid(&SIDAuthNull, 1, SECURITY_NULL_RID,
+                                0, 0, 0, 0, 0, 0, 0, &psidNull) ||
+      !AllocateAndInitializeSid(&SIDAuthCreator, 1, SECURITY_CREATOR_GROUP_RID,
+                                0, 0, 0, 0, 0, 0, 0, &psidCreatorGroup) ||
+      !AllocateAndInitializeSid(&SIDAuthWorld, 1, SECURITY_WORLD_RID,
+                                0, 0, 0, 0, 0, 0, 0, &psidEveryone)) {
+      SET_REQ_WIN32_ERROR(req, GetLastError());
+      goto chmod_cleanup;
+  }
+
+  /* Get the old DACL so that we can merge into it */
+  SECURITY_INFORMATION si = OWNER_SECURITY_INFORMATION |
+                            GROUP_SECURITY_INFORMATION |
+                            DACL_SECURITY_INFORMATION;
+  if (ERROR_SUCCESS != GetNamedSecurityInfoW(req->file.pathw, SE_FILE_OBJECT,
+                                             si, &psidOwner, &psidGroup,
+                                             &pOldDACL, NULL, &pSD)) {
+    DWORD err = GetLastError();
+    SET_REQ_WIN32_ERROR(req, err);
+    goto chmod_cleanup;
+  }
+
+  /* If the file does not contain a group owner, we will use the user's 'Creator Group ID' instead */
+  if (EqualSid(psidGroup, psidNull)) {
+    psidGroup = psidCreatorGroup;
+  }
+
+  /*
+   * We next need to scan all groups that the current user "belongs" to, in order to
+   * set the permissions for those groups to be the same as the "group" bit; so first
+   * we collect a list of group PSIDs:
+   */
+  DWORD numGroups = 0;
+  HANDLE hToken = NULL;
+  DWORD tokenAccess = TOKEN_IMPERSONATE |
+                      TOKEN_QUERY |
+                      TOKEN_DUPLICATE |
+                      STANDARD_RIGHTS_READ;
+  if (!OpenProcessToken(GetCurrentProcess(), tokenAccess, &hToken )) {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+    goto chmod_cleanup;
+  }
+  HANDLE hImpersonatedToken = NULL;
+  if (!DuplicateToken(hToken, SecurityImpersonation, &hImpersonatedToken)) {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+    goto chmod_cleanup;
+  }
+
+  /* Extract EAs from old DACL */
+  ULONG numOldEAs = 0;
+  ULONG numOtherGroups = 0;
+  ULONG ea_idx = 0;
+  if (ERROR_SUCCESS != GetExplicitEntriesFromAclW(pOldDACL, &numOldEAs,
+                                                  &poldEAs)) {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+    goto chmod_cleanup;
+  }
+
+  /* Iterate over all old ACEs, looking for groups that we belong to */
+  for (ea_idx=0; ea_idx<numOldEAs; ++ea_idx) {
+    PSID pEASid = (PSID)poldEAs[ea_idx].Trustee.ptstrName;
+    /* Skip this EA if it isn't an SID, or it is "Everyone" or our actual group */
+    if (poldEAs[ea_idx].Trustee.TrusteeForm != TRUSTEE_IS_SID ||
+        EqualSid(pEASid, psidEveryone) ||
+        EqualSid(pEASid, psidGroup)) {
+      continue;
+    }
+
+    /* Check to see if our user is a member of this group */
+    BOOL isMember = FALSE;
+    if (!CheckTokenMembership(hImpersonatedToken, pEASid, &isMember)) {
+      SET_REQ_WIN32_ERROR(req, GetLastError());
+      goto chmod_cleanup;
+    }
+
+    /* If we're a member, then count it */
+    if (isMember) {
+      numOtherGroups++;
+    }
+  }
+
+  /* Create an ACE for each triplet (user, group, other) */
+  int numEAs = 8 + 3*numOtherGroups;
+  ea = (PEXPLICIT_ACCESS_W) malloc(sizeof(EXPLICIT_ACCESS_W)*numEAs);
+  DWORD u_mode = ((req->fs.info.mode & S_IRWXU) >> 6);
+  DWORD g_mode = ((req->fs.info.mode & S_IRWXG) >> 3);
+  DWORD o_mode = ((req->fs.info.mode & S_IRWXO) >> 0);
+
+  /* We start by revoking previous permissions for trustees we care about */
+  build_access_struct(&ea[0], psidOwner,    TRUSTEE_IS_USER,  0, REVOKE_ACCESS);
+  build_access_struct(&ea[1], psidGroup,    TRUSTEE_IS_GROUP, 0, REVOKE_ACCESS);
+  build_access_struct(&ea[2], psidEveryone, TRUSTEE_IS_GROUP, 0, REVOKE_ACCESS);
+
+  /*
+   * We also add explicit denies to user and group if the user shouldn't have
+   * a permission but the group or everyone can, for instance.
+   */
+  DWORD u_deny_mode = (~u_mode) & (g_mode | o_mode);
+  DWORD g_deny_mode = (~g_mode) & o_mode;
+  build_access_struct(&ea[3], psidOwner, TRUSTEE_IS_USER,  u_deny_mode, DENY_ACCESS);
+  build_access_struct(&ea[4], psidGroup, TRUSTEE_IS_GROUP, g_deny_mode, DENY_ACCESS);
+
+  /* Next, add explicit allows for (owner, group, other) */
+  build_access_struct(&ea[5], psidOwner,    TRUSTEE_IS_USER,  u_mode, SET_ACCESS);
+  build_access_struct(&ea[6], psidGroup,    TRUSTEE_IS_GROUP, g_mode, SET_ACCESS);
+  build_access_struct(&ea[7], psidEveryone, TRUSTEE_IS_GROUP, o_mode, SET_ACCESS);
+
+  /*
+   * Iterate over all old ACEs, looking for groups that we belong to, and setting
+   * the appropriate access bits for those groups (as g_mode)
+   */
+  ULONG ea_write_idx = 8;
+  for (ea_idx=0; ea_idx<numOldEAs; ++ea_idx) {
+    PSID pEASid = (PSID)poldEAs[ea_idx].Trustee.ptstrName;
+    /* Skip this EA if it isn't an SID, or it is "Everyone" or our actual group */
+    if (poldEAs[ea_idx].Trustee.TrusteeForm != TRUSTEE_IS_SID ||
+        EqualSid(pEASid, psidEveryone) ||
+        EqualSid(pEASid, psidGroup)) {
+      continue;
+    }
+
+    /* Check to see if our user is a member of this group */
+    BOOL isMember = FALSE;
+    if (!CheckTokenMembership(hImpersonatedToken, pEASid, &isMember)) {
+      SET_REQ_WIN32_ERROR(req, GetLastError());
+      goto chmod_cleanup;
+    }
+
+    /*
+     * If we're a member, then count it.  We limit our `ea_write_idx` to avoid
+     * the unlikely event that we have been added to a group since we first
+     * calculated `numOtherGroups`.
+     */
+    if (isMember && ea_write_idx < numEAs) {
+      build_access_struct(&ea[ea_write_idx], pEASid, TRUSTEE_IS_GROUP, 0, REVOKE_ACCESS);
+      build_access_struct(&ea[ea_write_idx + 1], pEASid, TRUSTEE_IS_GROUP, g_deny_mode, DENY_ACCESS);
+      build_access_struct(&ea[ea_write_idx + 2], pEASid, TRUSTEE_IS_GROUP, g_mode, SET_ACCESS);
+      ea_write_idx += 3;
+    }
+  }
+
+  /*
+   * We next need to set all the "other group" entries for groups that already have
+   * ACEs present and which contain our user.
+   */
+  if (ERROR_SUCCESS != SetEntriesInAclW(numEAs, &ea[0], pOldDACL, &pNewDACL)) {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+    goto chmod_cleanup;
+  }
+
+  if (ERROR_SUCCESS != SetNamedSecurityInfoW(
+              req->file.pathw,
+              SE_FILE_OBJECT,
+              DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+              NULL, NULL, pNewDACL, NULL)) {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+    goto chmod_cleanup;
+  }
+
+  SET_REQ_SUCCESS(req);
+
+chmod_cleanup:
+  if (pSD != NULL) {
+    LocalFree(pSD);
+  }
+  if (pNewDACL != NULL) {
+    LocalFree(pNewDACL);
+  }
+  if (psidEveryone != NULL) {
+    FreeSid(psidEveryone);
+  }
+  if (psidNull != NULL) {
+    FreeSid(psidNull);
+  }
+  if (psidCreatorGroup != NULL) {
+    FreeSid(psidCreatorGroup);
+  }
+  if (poldEAs != NULL) {
+    LocalFree(poldEAs);
+  }
+  if (ea != NULL) {
+    free(ea);
+  }
 }
 
 


### PR DESCRIPTION
Given the building blocks here, we should also be able to upgrade `fs__stat()` to give reasonable results on Windows as well, but since it's not blocking anything, that's going to have to wait for a very, VERY, rainy day.