### PR TITLE
Unix: If the `statx` syscall returns EACCES or EPERM, fall back to regular `stat`/`lstat`/`fstat`

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1252,7 +1252,7 @@ static int uv__fs_stat(const char *path, uv_stat_t *buf) {
   int ret;
 
   ret = uv__fs_statx(-1, path, /* is_fstat */ 0, /* is_lstat */ 0, buf);
-  if (ret != UV_ENOSYS)
+  if (ret != UV_ENOSYS && ret != UV_EPERM && ret != UV_EACCES)
     return ret;
 
   ret = stat(path, &pbuf);
@@ -1268,7 +1268,7 @@ static int uv__fs_lstat(const char *path, uv_stat_t *buf) {
   int ret;
 
   ret = uv__fs_statx(-1, path, /* is_fstat */ 0, /* is_lstat */ 1, buf);
-  if (ret != UV_ENOSYS)
+  if (ret != UV_ENOSYS && ret != UV_EPERM && ret != UV_EACCES)
     return ret;
 
   ret = lstat(path, &pbuf);
@@ -1284,7 +1284,7 @@ static int uv__fs_fstat(int fd, uv_stat_t *buf) {
   int ret;
 
   ret = uv__fs_statx(fd, "", /* is_fstat */ 1, /* is_lstat */ 0, buf);
-  if (ret != UV_ENOSYS)
+  if (ret != UV_ENOSYS && ret != UV_EPERM && ret != UV_EACCES)
     return ret;
 
   ret = fstat(fd, &pbuf);


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/34918

---

If you try to make the `statx` syscall inside a non-privileged container (e.g. a non-privileged Docker container), you will get `EACCES` or `EPERM`. This error does not actually mean that the file/directory that you are `stat`-ing has a permissions error. Rather, it means that inside the non-privileged container, you are not permitted to make the `statx` syscall.

If this happens, we should fall back to the regular `stat`/`lstat`/`fstat`, which work perfectly fine inside non-privileged containers.

cc: @Keno @vtjnash 