### PR TITLE
Remove incorrect constant in chmod

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1798,7 +1798,7 @@ static void build_access_struct(EXPLICIT_ACCESS_W* ea, PSID owner,
   }
 
   if (mode_triplet & 0x4) {
-    ea->grfAccessPermissions |= FILE_GENERIC_READ | FILE_TRAVERSE | FILE_WRITE_ATTRIBUTES;
+    ea->grfAccessPermissions |= FILE_GENERIC_READ | FILE_WRITE_ATTRIBUTES;
   }
 }
 


### PR DESCRIPTION
`FILE_TRAVERSE` is the same thing as `FILE_EXECUTE`, and by default, processes do not need `FILE_TRAVERSE` enabled on directories to traverse them [1].

[1] https://docs.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants