### PR TITLE
[win,fs]: Give `DELETE` writes with the `w` permission

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2295,7 +2295,7 @@ static void build_access_struct(EXPLICIT_ACCESS_W* ea, PSID owner,
   }
 
   if (mode_triplet & 0x2) {
-    ea->grfAccessPermissions |= STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_EA | FILE_APPEND_DATA | FILE_ADD_SUBDIRECTORY | FILE_DELETE_CHILD;
+    ea->grfAccessPermissions |= STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_EA | FILE_APPEND_DATA | FILE_ADD_SUBDIRECTORY | FILE_DELETE_CHILD | DELETE;
     if (allow_deny == GRANT_ACCESS) {
       ea->grfAccessPermissions |= SYNCHRONIZE | FILE_WRITE_ATTRIBUTES;
     }


### PR DESCRIPTION
Windows has a default permissions inheritance scheme setup whereby
files/folders created in the user's home directory are (by default)
deletable by that same user.  Creating folders in the root C: do not
inherit those same permissions, and as such may inadvertently have their
delete permissions stripped by a `chmod()`.

@musm confirms that this fixes the recently-observed windows permissions issues.