### PR TITLE
Backport (unmerged) changes for further cgroupv2 compat

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -562,7 +562,7 @@ API
 
 .. c:function:: uint64_t uv_get_constrained_memory(void)
 
-    Gets the amount of memory available to the process (in bytes) based on
+    Gets the total amount of memory available to the process (in bytes) based on
     limits imposed by the OS. If there is no such constraint, or the constraint
     is unknown, `0` is returned. Note that it is not unusual for this value to
     be less than or greater than :c:func:`uv_get_total_memory`.
@@ -572,6 +572,20 @@ API
         on cgroups if it is present, and on z/OS based on RLIMIT_MEMLIMIT.
 
     .. versionadded:: 1.29.0
+
+.. c:function:: uint64_t uv_get_available_memory(void)
+
+    Gets the amount of free memory that is still available to the process (in bytes).
+    This differs from :c:func:`uv_get_free_memory` in that it takes into account any
+    limits imposed by the OS. If there is no such constraint, or the constraint
+    is unknown, the amount returned will be identical to :c:func:`uv_get_free_memory`.
+
+    .. note::
+        This function currently only returns a value that is different from
+        what :c:func:`uv_get_free_memory` reports on Linux, based
+        on cgroups if it is present.
+
+    .. versionadded:: 1.45.0
 
 .. c:function:: uint64_t uv_hrtime(void)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1793,6 +1793,7 @@ UV_EXTERN int uv_chdir(const char* dir);
 UV_EXTERN uint64_t uv_get_free_memory(void);
 UV_EXTERN uint64_t uv_get_total_memory(void);
 UV_EXTERN uint64_t uv_get_constrained_memory(void);
+UV_EXTERN uint64_t uv_get_available_memory(void);
 
 UV_EXTERN uint64_t uv_hrtime(void);
 UV_EXTERN void uv_sleep(unsigned int msec);

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -382,6 +382,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   perfstat_cpu_total_t ps_total;
   int result = perfstat_cpu_total(NULL, &ps_total, sizeof(ps_total), 1);

--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -51,3 +51,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 uint64_t uv_get_constrained_memory(void) {
   return 0;  /* Memory constraints are unknown. */
 }
+
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -131,6 +131,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -116,6 +116,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -84,6 +84,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   area_info area;
   ssize_t cookie;

--- a/src/unix/hurd.c
+++ b/src/unix/hurd.c
@@ -165,3 +165,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 uint64_t uv_get_constrained_memory(void) {
   return 0;  /* Memory constraints are unknown. */
 }
+
+
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -249,6 +249,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   SSTS0200 rcvr;
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -844,6 +844,49 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+static uint64_t uv__get_available_memory_fallback(void) {
+  uint64_t current;
+  uint64_t constrained;
+
+  constrained = uv__get_constrained_memory_fallback();
+  if (constrained == 0)
+    return uv_get_free_memory();
+
+  current = uv__read_uint64("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+  return constrained - current;
+}
+
+
+uint64_t uv_get_available_memory(void) {
+  char filename[4097];
+  char buf[1024];
+  uint64_t current;
+  uint64_t constrained;
+  char* p;
+
+  constrained = uv_get_constrained_memory();
+  if (constrained == 0)
+    return uv__get_available_memory_fallback();
+
+  if (uv__slurp("/proc/self/cgroup", buf, sizeof(buf)))
+    return uv__get_available_memory_fallback();
+
+  if (memcmp(buf, "0::/", 4))
+    return uv__get_available_memory_fallback();
+
+  p = strchr(buf, '\n');
+  if (p != NULL)
+    *p = '\0';
+
+  p = buf + 4;
+
+  snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%s/memory.current", p);
+  current = uv__read_uint64(filename);
+
+  return constrained - current;
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct sysinfo info;
   char buf[128];  /* Large enough to hold all of /proc/loadavg. */

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -131,6 +131,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   kvm_t *kd = NULL;
   struct kinfo_proc2 *kinfo = NULL;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -139,6 +139,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   struct kinfo_proc kinfo;
   size_t page_size = getpagesize();

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -198,6 +198,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   char* ascb;
   char* rax;

--- a/src/unix/qnx.c
+++ b/src/unix/qnx.c
@@ -88,6 +88,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   int fd;
   procfs_asinfo asinfo;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -403,6 +403,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   (void) getloadavg(avg, 3);
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -356,6 +356,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 uv_pid_t uv_os_getpid(void) {
   return GetCurrentProcessId();
 }

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -26,11 +26,13 @@ TEST_IMPL(get_memory) {
   uint64_t free_mem = uv_get_free_memory();
   uint64_t total_mem = uv_get_total_memory();
   uint64_t constrained_mem = uv_get_constrained_memory();
+  uint64_t available_mem = uv_get_available_memory();
 
-  printf("free_mem=%llu, total_mem=%llu, constrained_mem=%llu\n",
+  printf("free_mem=%llu, total_mem=%llu, constrained_mem=%llu, available_memo=%llu\n",
          (unsigned long long) free_mem,
          (unsigned long long) total_mem,
-         (unsigned long long) constrained_mem);
+         (unsigned long long) constrained_mem,
+         (unsigned long long) available_mem);
 
   ASSERT(free_mem > 0);
   ASSERT(total_mem > 0);
@@ -40,5 +42,6 @@ TEST_IMPL(get_memory) {
 #else
   ASSERT(total_mem > free_mem);
 #endif
+  ASSERT(available_mem <= free_mem);
   return 0;
 }


### PR DESCRIPTION
Used in https://github.com/JuliaLang/julia/pull/46796

It's likely that upstream won't accept these changes in their current form, but since it only introduces an additional API call I guess it probably can't hurt to include this eagerly (for 1.8.2 or 1.8.3, as requested by others) and re-synchronize with upstream at a later point.