### PR TITLE
[Windows] Allow exceptions through to the OS

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -69,10 +69,6 @@ void uv__wake_all_loops() {
 }
 
 static void uv__init(void) {
-  /* Tell Windows that we will handle critical errors. */
-  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
-               SEM_NOOPENFILEERRORBOX);
-
   /* Initialize tracking of all uv loops */
   uv__loops_init();
 

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -85,7 +85,6 @@ static void uv__init_global_job_handle(void) {
   info.BasicLimitInformation.LimitFlags =
       JOB_OBJECT_LIMIT_BREAKAWAY_OK |
       JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK |
-      JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION |
       JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 
   uv_global_job_handle_ = CreateJobObjectW(&attr, NULL);
@@ -1073,7 +1072,7 @@ int uv_spawn(uv_loop_t* loop,
   startup.hStdOutput = uv__stdio_handle(process->child_stdio_buffer, 1);
   startup.hStdError = uv__stdio_handle(process->child_stdio_buffer, 2);
 
-  process_flags = CREATE_UNICODE_ENVIRONMENT;
+  process_flags = CREATE_UNICODE_ENVIRONMENT | CREATE_DEFAULT_ERROR_MODE;
 
   if ((options->flags & UV_PROCESS_WINDOWS_HIDE_CONSOLE) ||
       (options->flags & UV_PROCESS_WINDOWS_HIDE)) {


### PR DESCRIPTION
In order to properly generate minidumps during actual events, it is necessary to disable the call to `SetErrorMode()` during libuv initialization and to remove the job flag
`JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION`, both of which interfered in the normal handling of exceptions.  Finally, it was determined prudent to include `CREATE_DEFAULT_ERROR_MODE` when spawning new processes, to ensure that whatever error handling mode was set in the current process is not inherited by subprocesses.