### PR TITLE
win: compute parallelism from process cpu affinity (#4521)

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -513,19 +513,23 @@ int uv_uptime(double* uptime) {
 
 
 unsigned int uv_available_parallelism(void) {
-  SYSTEM_INFO info;
-  unsigned rc;
+  DWORD_PTR procmask;
+  DWORD_PTR sysmask;
+  int count;
+  int i;
 
   /* TODO(bnoordhuis) Use GetLogicalProcessorInformationEx() to support systems
    * with > 64 CPUs? See https://github.com/libuv/libuv/pull/3458
    */
-  GetSystemInfo(&info);
+  count = 0;
+  if (GetProcessAffinityMask(GetCurrentProcess(), &procmask, &sysmask))
+    for (i = 0; i < 64; i++)  /* a.k.a. count = popcount(procmask); */
+      count += 1 & (procmask >> i);
 
-  rc = info.dwNumberOfProcessors;
-  if (rc < 1)
-    rc = 1;
+  if (count > 0)
+    return count;
 
-  return rc;
+  return 1;
 }
 
 


### PR DESCRIPTION
`uv_available_parallelism` on Windows is currently inconsistent with `uv_thread_getaffinity`.  This backports https://github.com/libuv/libuv/pull/4521 which fixes this issue.