### PR TITLE
win: fix uv_available_parallelism on win32 (#4525)

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -523,7 +523,7 @@ unsigned int uv_available_parallelism(void) {
    */
   count = 0;
   if (GetProcessAffinityMask(GetCurrentProcess(), &procmask, &sysmask))
-    for (i = 0; i < 64; i++)  /* a.k.a. count = popcount(procmask); */
+    for (i = 0; i < 8 * sizeof(procmask); i++)
       count += 1 & (procmask >> i);
 
   if (count > 0)


### PR DESCRIPTION
Follow up to #38, backports https://github.com/libuv/libuv/pull/4525